### PR TITLE
Only run unique constraint checks on the constraint fields

### DIFF
--- a/Resources/public/js/FpJsFormValidator.js
+++ b/Resources/public/js/FpJsFormValidator.js
@@ -233,7 +233,7 @@ function FpJsCustomizeMethods() {
                 if (data['entity'] && data['entity']['constraints']) {
                     for (var i in data['entity']['constraints']) {
                         var constraint = data['entity']['constraints'][i];
-                        if (constraint instanceof FpJsFormValidatorBundleFormConstraintUniqueEntity && constraint.fields.indexOf(item.name)) {
+                        if (constraint instanceof FpJsFormValidatorBundleFormConstraintUniqueEntity && constraint.fields.indexOf(item.name) > -1) {
                             var owner = item.jsFormValidator.parent;
                             constraint.validate(null, owner);
                         }


### PR DESCRIPTION
`constraint.fields.indexOf(item.name)` returns -1 if `item.name` is not found, and -1 converts to true (only 0 converts to false, every other integer converts to true), thus this change
